### PR TITLE
Fixed account analytics links 'uniswap.info' -> 'info.eggs.cool' 

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -280,7 +280,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
             <ButtonSecondary padding="8px" borderRadius="8px">
               <ExternalLink
                 style={{ width: '100%', textAlign: 'center' }}
-                href={`https://uniswap.info/account/${account}`}
+                href={`https://info.eggs.cool/account/${account}`}
               >
                 View accrued fees and analytics<span style={{ fontSize: '11px' }}>↗</span>
               </ExternalLink>

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -174,7 +174,7 @@ export default function Pool() {
               <>
                 <ButtonSecondary>
                   <RowBetween>
-                    <ExternalLink href={'https://uniswap.info/account/' + account}>
+                    <ExternalLink href={'https://info.eggs.cool/account/' + account}>
                       Account analytics and accrued fees
                     </ExternalLink>
                     <span> ↗</span>


### PR DESCRIPTION
Fixed account analytics links from 'uniswap.info' to 'info.eggs.cool' for liquidity provider manage page
![image](https://user-images.githubusercontent.com/2872443/111021096-c7007980-83d2-11eb-9255-5405f3704a46.png)
